### PR TITLE
Updated Homepage banner with Announcement, Added Student Outcomes Section, Added Curriculum Section

### DIFF
--- a/src/components/card.module.css
+++ b/src/components/card.module.css
@@ -1,0 +1,61 @@
+* {
+    box-sizing: border-box;
+  }
+  
+  body {
+    font-family: Arial, Helvetica, sans-serif;
+  }
+  
+  /* Float four columns side by side */
+  .column {
+    float: left;
+    width: 25%;
+    padding: 0 10px;
+  }
+  
+  /* Remove extra left and right margins, due to padding in columns */
+  .row {
+      display: flex;
+      justify-content: space-evenly;
+      margin-bottom: 20px;
+    }
+  
+  /* Clear floats after the columns */
+  .row:after {
+    content: "";
+    display: table;
+    clear: both;
+  }
+  
+  /* Style the counter cards */
+  .card {
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2); /* this adds the "card" effect */
+    padding: 16px;
+    text-align: center;
+    background-color: #f5f5f5;
+    margin-bottom: 15px;
+    border-radius: 10px;
+    border-color: #f5f5f5;
+  }
+
+  .stat {
+     font-size: 50px;
+     font-weight: bold;
+     color: #33d5c3;
+  }
+
+  .value {
+    margin-top: 10px;
+    font-size: 17px;
+    letter-spacing: 1px;
+    margin-bottom: 10px;
+  }
+  
+  /* Responsive columns - one column layout (vertical) on small screens */
+  @media screen and (max-width: 600px) {
+    .column {
+      width: 100%;
+      display: block;
+      margin-bottom: 20px;
+    }
+  }

--- a/src/content/content.json
+++ b/src/content/content.json
@@ -16,6 +16,10 @@
       "text": "In the News: Hack Upstate Receives Three Years of Funding from the Alliance for Economic Inclusion",
       "link": "https://www.governor.ny.gov/news/governor-cuomo-announces-39-projects-be-funded-through-round-two-alliance-economic-inclusion?fbclid=IwAR1ZRhe0K5w0R5f1VgsFRfkVOMCV3biMVU7vPrzp5v5HGFVeEiHf71R87ZY"
     },
+    "index_banner_announce": {
+      "text": "Announcing Careers in Code’s Second Cohort in Partnership With Le Moyne College’s ERIE 21 and CenterState CEO",
+      "link": "https://medium.com/@hackupstate/announcing-careers-in-codes-second-cohort-in-partnership-with-le-moyne-college-s-erie-21-and-1f70134b4352"
+    },
     "index_main_content_top_text": {
       "copy": "Poverty throughout Central NY is rising at an accelerated rate and stifling our region's economic potential.",
       "description": "There are few opportunities for women and minorities to advance in concentrated areas of extreme poverty.",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -204,6 +204,24 @@ const IndexPage = (props) => (
       </Row>
     </Container>
 
+    <Container fluid className={pageStyles.blueContainer}>
+      <Row className={bannerStyles.bannerWhite}>
+        <Col className={pageStyles.centerText}>
+          <h3>A Curriculum Informed by Local Employers</h3>
+          <p>We partner with local employers to develop and provide feedback on our curriculum.</p>
+          <a
+              href="/partner"
+              rel="noopener noreferrer"
+              className={testimonialStyles.btnLink}
+            >
+          <Button size="md" className={testimonialStyles.blueButton}>
+              Partners
+          </Button>
+          </a>
+        </Col>
+      </Row>
+    </Container>
+
     <BottomRowContainer />
   </Layout>
 );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -54,12 +54,12 @@ const IndexPage = (props) => (
       <Row className={bannerStyles.bannerGreen}>
         <Col className={pageStyles.centerText}>
           <a
-            href={content.ui.index_banner.link}
+            href={content.ui.index_banner_announce.link}
             target="_blank"
             rel="noopener noreferrer"
             className={pageStyles.bannerLink}
           >
-            {content.ui.index_banner.text}{" "}
+            {content.ui.index_banner_announce.text}{" "}
             <FontAwesomeIcon icon={faArrowRight} size="1x" />
           </a>
         </Col>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -26,6 +26,7 @@ import Joey from "../images/instructors/joeybuczek.jpg";
 import Kelly from "../images/students/kellycorey.jpg";
 import Doug from "../images/team/dougcrescenzi.png";
 import content from "../content/content.json";
+import cardStyles from "../components/card.module.css";
 import pageStyles from "./pages.module.css";
 import bannerStyles from "../components/banner.module.css";
 import testimonialStyles from "./testimonials.module.css";
@@ -99,6 +100,7 @@ const IndexPage = (props) => (
         </Col>
       </Row>
     </Container>
+         
     <Container fluid className={testimonialStyles.blueContainer}>
       <Row>
         <CardDeck>
@@ -186,9 +188,44 @@ const IndexPage = (props) => (
     <Container fluid className={pageStyles.whiteContainer}>
       <Row className={bannerStyles.bannerWhite}>
         <Col className={pageStyles.centerText}>
+        <h2 className={pageStyles.outcomes}>Our Cohort 1 Students Saw Results</h2>
+          <p>We graduated 11 students on August 22, 2019 with the following outcomes.</p>
+          <Row className={cardStyles.row}>
+          <Card className={cardStyles.card}>
+            <span className={cardStyles.stat}>91%</span>
+            <span className={cardStyles.value}>Graduation Rate</span>
+          </Card>
+          <Card className={cardStyles.card}>
+          <span className={cardStyles.stat}>63%</span>
+          <span className={cardStyles.value}>Placement Rate</span>
+          </Card>
+          <Card className={cardStyles.card}>
+          <span className={cardStyles.stat}>56%</span>
+          <span className={cardStyles.value}>Salary Increase</span>
+          </Card>
+          <Card className={cardStyles.card}>
+          <span className={cardStyles.stat}>$45,490</span>
+          <span className={cardStyles.value}>Average Starting Salary</span>
+          </Card>
+          </Row>
+          <a
+              href="https://careersincode.org/Careers-in-Code-Cohort-1-Outcomes-2-pager.pdf"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={testimonialStyles.btnLink}
+            >
+          <Button size="md" className={testimonialStyles.blueButton}>
+              View Cohort 1 Outcomes
+          </Button>
+          </a>
+          </Col>
+      </Row>
+    </Container>
+    <Container fluid className={pageStyles.whiteContainer}>
+      <Row className={bannerStyles.bannerWhite}>
+        <Col className={pageStyles.centerText}>
           <img src={cirrLogo} alt="CIRR Logo"></img>
           <h3>Graduate Outcomes You Can Trust</h3>
-          <p>We graduated 11 students on August 22, 2019. 7 of 11 of our graduates have been placed in in-field internships, entry level positions, or consulting arrangements with an average salary increase of ~56%.</p>
           <p>As a CIRR certified school, we fully offer transparent results. CIRR is the industry standard for placement stats and we are commited to publishing trustworthy graduate outcomes.</p>
           <a
               href="https://cirr.org/"

--- a/src/pages/pages.module.css
+++ b/src/pages/pages.module.css
@@ -118,6 +118,11 @@ tr {
   font-size: 16px;
 }
 
+.outcomes {
+font-size: 35px;
+font-weight: bold;
+}
+
 h3 {
   margin-bottom: 1rem;
   margin-top: 1rem;


### PR DESCRIPTION
Trello Card Items:

- Update the banner on the home page to read Announcing Careers in Code’s Second Cohort in Partnership With Le Moyne College’s ERIE 21 and CenterState CEO // https://medium.com/@hackupstate/announcing-careers-in-codes-second-cohort-in-partnership-with-le-moyne-college-s-erie-21-and-1f70134b4352
- Include outcomes on the homepage somewhere (i.e. something like this translated to code - https://careersincode.org/Careers-in-Code-Cohort-1-Outcomes-2-pager.pdf)
- Some mention of our curriculum and how it's informed by local employers

Solution:
Updated `index.js`, `content.json`
Added `card.module.css`